### PR TITLE
Feature/insert size plot

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,17 +1,19 @@
 FROM python:3.8-slim-buster
 
-ARG FEATURE_BRANCH=feature/hsmetrics
-
-WORKDIR /usr/bin
-
-# Copy data from the volume into the container
-COPY . .
+ARG FEATURE_BRANCH=feature/insert_size_plot
 
 RUN apt-get clean \
     && apt-get update -qq \
     && apt-get install -y git \
-    && cd /usr/bin \
+    && mkdir /usr/bin/app \
+    && cd /usr/bin/app \
     && git clone https://github.com/mskcc/collect-qc.git --branch ${FEATURE_BRANCH} \
-    && pip install -r collect-qc/requirements.txt 
+    && pip install -r collect-qc/requirements.txt
 
-CMD ["python", "collect-qc/main.py"]
+# Mount the repo onto a volume
+VOLUME /usr/bin/app/collect-qc
+
+# Change to the directory with the config.yaml and data files
+WORKDIR /usr/bin/app
+
+CMD [ "python", "/usr/bin/app/collect-qc/main.py" ]

--- a/metric.py
+++ b/metric.py
@@ -11,21 +11,21 @@ import yaml
 class Metric:
     def __init__(self):
         self.config = None
-        self.qc_data_path = None
+        self.qc_folder = None
 
     def load_config(self, config_file):
         with open(config_file) as f:
-            config = yaml.safe_load(f)
-        self.qc_data_path = config["qc_data_path"]
+            self.config = yaml.safe_load(f)
+        self.qc_folder = os.path.join(os.getcwd(), self.config["qc_folder"])
         if not os.path.exists("plots"):
             os.mkdir("plots")
-        return config
+        return self.config
 
     def hsmetrics(self, operator, operand):
-        runs = os.listdir(self.qc_data_path)
+        runs = os.listdir(self.qc_folder)
         hsmetrics_data = []
         for run in runs:
-            run_path = os.path.join(self.qc_data_path, run)
+            run_path = os.path.join(self.qc_folder, run)
             for run_file in os.listdir(run_path):
                 if run_file.endswith(".hsmetrics"):
                     with open(os.path.join(run_path, run_file)) as f:
@@ -90,12 +90,12 @@ class Metric:
         return hsmetrics_out
 
     def insert_size(self, operator, operand):
-        runs = os.listdir(self.qc_data_path)
+        runs = os.listdir(self.qc_folder)
         insert_size_data = []
         fig, ax = plt.subplots(figsize=(20, 10), sharex=True, sharey=True)
         x_lim = float("inf")
         for run in runs:
-            run_path = os.path.join(self.qc_data_path, run)
+            run_path = os.path.join(self.qc_folder, run)
             for run_file in os.listdir(run_path):
                 if run_file.endswith(".ismetrics"):
                     with open(os.path.join(run_path, run_file)) as f:

--- a/metric.py
+++ b/metric.py
@@ -154,7 +154,7 @@ class Metric:
         plt.xlabel("Insert Size")
         plt.xlim(0, round(x_lim / 100) * 100)
         plt.grid()
-        plt.tight_layout()
+        plt.tight_layout(pad=3)
         plt.title("Insert Size Distribution", loc="left", fontsize=20)
         plt.savefig("plots/insert_size.png")
         insert_size_out = "\n".join(insert_size_data)

--- a/metric.py
+++ b/metric.py
@@ -17,7 +17,8 @@ class Metric:
         with open(config_file) as f:
             config = yaml.safe_load(f)
         self.qc_data_path = config["qc_data_path"]
-        os.mkdir("plots")
+        if not os.path.exists("plots"):
+            os.mkdir("plots")
         return config
 
     def hsmetrics(self, operator, operand):

--- a/metric.py
+++ b/metric.py
@@ -127,13 +127,13 @@ class Metric:
 
                         max_peak_idx = peak_data.idxmax()
                         max_peak = tab_data.iloc[:, 0].iloc[max_peak_idx]
-                        plot_label = f'{run_file.split(".")[0]} peak: {max_peak}'
+                        legend_label = f'{run_file.split(".")[0]} Peak: {max_peak}'
                         sns.lineplot(
                             data=tab_data,
                             x=tab_data.columns[0],
                             y=tab_data.columns[1],
                             ax=ax,
-                            label=plot_label,
+                            label=legend_label,
                         )
                         x_lim = min(x_lim, tab_data.iloc[:, 0].max())
 
@@ -143,19 +143,19 @@ class Metric:
                         peak_amt = len(peaks[0])
                         if peak_amt == 1:
                             insert_size_data.append(
-                                f'{colored("PASS", color="green", attrs=["bold"])} {run_file.split(".")[0]}, peaks: {len(peaks[0])}, max_peak: {max_peak}'
+                                f'{colored("PASS", color="green", attrs=["bold"])} {run_file.split(".")[0]}, Peaks: {len(peaks[0])}, Max Peak: {max_peak}'
                             )
                         else:
                             insert_size_data.append(
-                                f'{colored("FAIL", color="red", attrs=["bold"])} {run_file.split(".")[0]}, peaks: {len(peaks[0])}, max_peak: {max_peak}'
+                                f'{colored("FAIL", color="red", attrs=["bold"])} {run_file.split(".")[0]}, Peaks: {len(peaks[0])}, Max Peak: {max_peak}'
                             )
-
+        ax.set_facecolor("#eeeeee")
         plt.ylabel("")
         plt.xlabel("Insert Size")
         plt.xlim(0, round(x_lim / 100) * 100)
         plt.grid()
         plt.tight_layout()
-        plt.title("Insert Size Distribution")
+        plt.title("Insert Size Distribution", loc="left", fontsize=20)
         plt.savefig("plots/insert_size.png")
         insert_size_out = "\n".join(insert_size_data)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
+matplotlib
 pandas
 pyyaml
 scipy
+seaborn
 termcolor


### PR DESCRIPTION
The insert size function of the Metric class will now output a plot with the insert size distributions. The docker container has been reconfigured to share a volume between the repository cloned in the container and the source directory with the config.yaml and data folder on the host. 

To run the container:

1. Make a directory containing the data folder, config.yaml, and Dockerfile, and build the container.
2. Run the container with the following command in the directory from Step 1:
`docker run -it -v "$(pwd)":/usr/bin/app {CONTAINER NAME} `

This will mount a volume between the current directory and /usr/bin/app of the container. You will notice that two folders will be created in your current directory when running: collect-qc, plots. The collect-qc folder is made because a volume had to be created in the container for the repository in order for the host to access the repository in the container to run the code on their data files (a bind mount is created between the current directory and the container).

config.yaml used for testing (qc_folder is the name of the folder containing the qc data files):
```
qc_folder: "collect-qc-test-data"

metrics:
  hsmetrics:
    function:
      mean_target_coverage:
        warn: 500
        error: 300
  insert_size:
    function:
      table:
        columns: [1, 2]
```

#2 #13 